### PR TITLE
Modify 'stacked_encoder' to 'encoder'

### DIFF
--- a/allennlp_config/elmo_tagger.json
+++ b/allennlp_config/elmo_tagger.json
@@ -32,7 +32,7 @@
             }
         
     },
-    "stacked_encoder": {
+    "encoder": {
             "type": "lstm",
             "input_size": 1124,
             "hidden_size": 256,

--- a/allennlp_config/simple_tagger.json
+++ b/allennlp_config/simple_tagger.json
@@ -35,7 +35,7 @@
               "dropout": 0.2
             }
     },
-    "stacked_encoder": {
+    "encoder": {
             "type": "lstm",
             "input_size": 100,
             "hidden_size": 100,


### PR DESCRIPTION
After the very early version of allennlp, stacked_encoder is merged into encoder
(related issue https://github.com/sebastianGehrmann/bottom-up-summary/issues/6)