### PR TITLE
write valid JSON

### DIFF
--- a/preprocess_copy.py
+++ b/preprocess_copy.py
@@ -37,7 +37,7 @@ def compile_substring(start, end, split):
     return " ".join(split[start:end+1])
 
 def format_json(s):
-    return "{\"sentence\": \""+ s +"\"}\n"
+    return json.dumps({'sentence':s})+"\n"
 
 def splits(s, num=200):
     return s.split()[:num]


### PR DESCRIPTION
Write valid JSON to file when sentence contains characters that need to be escaped.

The original line can write invalid JSON. The invalid JSON causes allennlp to crash when it tries to load the JSON data during prediction.